### PR TITLE
chore(examples): update registry org in example

### DIFF
--- a/examples/compute/porter.yaml
+++ b/examples/compute/porter.yaml
@@ -1,8 +1,7 @@
-name: porter-gcloud-compute
+name: gcloud-compute
 version: 0.1.0
 description: "An example Porter gcloud compute bundle"
-invocationImage: deislabs/porter-gcloud-compute-installer:v0.1.0
-tag: deislabs/porter-gcloud-compute:v0.1.0
+tag: getporter/gcloud-compute
 
 mixins:
   - gcloud


### PR DESCRIPTION
* updates registry org in example as part of rm-ing `deislabs` strings in favor of the `getporter` org  (these were the only instances of `deislabs` found)